### PR TITLE
Add dialog options to decline duel after boarding

### DIFF
--- a/PROGRAM/DIALOGS/Cabinfight_dialog.c
+++ b/PROGRAM/DIALOGS/Cabinfight_dialog.c
@@ -281,6 +281,17 @@ trace("No reputation was assigned. Randomly assigning reputation " + NPChar.repu
 						Link.l1 = DLG_TEXT[151];
 					}
 					Link.l1.go = "kill_captain";
+
+					Link.l2 = DLG_TEXT[165];
+					Link.l3 = DLG_TEXT[164];
+					if (GetCrewQuantity(PChar) > GetCrewQuantity(NPChar) ) {
+						Link.l2.go = "duel_decline_prisoner_succeed";
+						Link.l3.go = "duel_decline_execute_succeed";
+					}
+					else {
+						Link.l2.go = "duel_decline_prisoner_fail";
+						Link.l3.go = "duel_decline_execute_fail";
+					}
 				}
 				else
 				{// added by MAXIMUS 26.08.2006 [if enemy captain is stronger than player, you'll fight with him] <--
@@ -383,6 +394,34 @@ trace("No reputation was assigned. Randomly assigning reputation " + NPChar.repu
 				}//MAXIMUS
 			}
 			NextDiag.TempNode = "first time";
+		break;
+
+		case "duel_decline_prisoner_fail":
+			dialog.text = DLG_TEXT[160];
+			Link.l1 = DLG_TEXT[161];
+			Link.l1.go = "kill_captain";
+			ChangeCharacterReputation(PChar, -1);
+		break;
+
+		case "duel_decline_prisoner_succeed":
+			dialog.text = DLG_TEXT[158];
+			Link.l1 = DLG_TEXT[159];
+			Link.l1.go = "take_as_prisoner";
+			ChangeCharacterReputation(PChar, -1);
+		break;
+
+		case "duel_decline_execute_fail":
+			dialog.text = DLG_TEXT[160];
+			Link.l1 = DLG_TEXT[161];
+			Link.l1.go = "kill_captain";
+			ChangeCharacterReputation(PChar, -3);
+		break;
+
+		case "duel_decline_execute_succeed":
+			dialog.text = DLG_TEXT[162];
+			Link.l1 = DLG_TEXT[163];
+			Link.l1.go = "exit_hanged";
+			ChangeCharacterReputation(PChar, -3);
 		break;
 
 		case "talk":

--- a/PROGRAM/DIALOGS/ENGLISH/Cabinfight_dialog.h
+++ b/PROGRAM/DIALOGS/ENGLISH/Cabinfight_dialog.h
@@ -1,4 +1,4 @@
-string DLG_TEXT[158] = {
+string DLG_TEXT[166] = {
 "I'll report this cruelty to the government of ",
 "! This is treachery!",
 "Dirty rat! How dare you attack a ship under the flag of ", 
@@ -157,4 +157,12 @@ string DLG_TEXT[158] = {
 "Isn't the meaning clear? I mean to take your ship. And your cargo. And your life.",
 "Traitor! I'll see you in Hell!",
 "Quite likely, but you'll be there before me.",
+"You dishonourable bastard! this will not be forgotten!",
+"Be quiet before i change my mind and have you killed instead!",
+"My crew may have surrendered but they are still loyal to me! your men are outnumbered. EN GARDE!",
+"It appears i have little choice, very well.",
+"You'll have your crew do your dirtywork rather than fight me like a man?! Typical Pirate! You'll not get away with this!",
+"ENOUGH! Stop your whining or ill make sure you die slow!",
+"Why would i waste my time duelling you when i can have my crew kill you instead! BOYS! HAVE YOUR FUN!",
+"Duel you? how about my men just throw you in the brig.",
 };


### PR DESCRIPTION
Allow the player to decline a duel with an enemy captain, at the cost of reputation.