### PR TITLE
Added "Talk to Self" feature

### DIFF
--- a/PROGRAM/BATTLE_INTERFACE/LandInterface.c
+++ b/PROGRAM/BATTLE_INTERFACE/LandInterface.c
@@ -12,6 +12,34 @@ bool bLandInterfaceStart = false;
 
 bool bInterlocutorActive = false; // KK
 
+
+bool bSelfDialogTurn = true; // Vex: Self Dialog Port; changes whether the player turns to face the camera when talking to themself
+
+// Vex: Self Dialog Port -->
+void StartActorSelfDialog(string _CurrentNode)
+{
+	ref pchar = GetMainCharacter();
+	pchar.Dialog.Filename = "MainHero_dialog.c";
+    LAi_SetActorType(pchar);
+    locCameraSleep(true);
+
+	if(bSelfDialogTurn){
+		 LAi_CharacterSaveAy(pchar);
+		if (stf(pchar.chr_ai.type.ay) > 0)
+		{
+			CharacterTurnAy(pchar,  -PI + abs(stf(pchar.chr_ai.type.ay)));  // 180 == 1
+		}
+		else
+		{
+			CharacterTurnAy(pchar,  PI - abs(stf(pchar.chr_ai.type.ay)));  // 180 == 1
+		}
+	}
+   
+    pchar.Dialog.CurrentNode = _CurrentNode;
+    LAi_ActorSelfDialog(pchar, "pchar_back_to_player");
+}
+// <-- Vex: Self Dialog Port
+
 void procBattleCommandSound()
 {
 	string comName = GetEventData();
@@ -197,6 +225,12 @@ ref BLI_CheckCommand()
 		case "BI_DialogStart":
 			g_intRetVal = 0;
 		break;
+		
+		// Vex: Self Dialog Port -->
+		case "BI_TalkSelf":
+			g_intRetVal = 0;
+		break;
+		// <-- Vex: Self Dialog Port
 
 		case "BI_ItemsChange":
 			g_intRetVal = 0;
@@ -282,6 +316,11 @@ void BLI_ExecuteCommand()
 			if(tmpi>=0 && !CheckAttribute(tmpChar, "corpse"))	Event("dlgReady","l",tmpi);
 			else Event("dlgReady","l",tmpi); //Log_SetStringToLog(TranslateString("","Gamlet")); //Levis: CORPSEMODE 3 fix, Remove event to revert
 		break;
+		// Vex: Self Dialog Port -->
+		case "BI_TalkSelf":
+			StartActorSelfDialog("TalkSelf_Main");
+		break;
+		// <-- Vex: Self Dialog Port
 		case "BI_ItemsChange":
 			tmpi = SendMessage(GetMainCharacter(),"ls",MSG_CHARACTER_EX_MSG,"FindDialogCharacter");
 			if(tmpi>=0)	LaunchCharacterItemChange(GetCharacter(tmpi));
@@ -498,6 +537,14 @@ void BLI_SetObjectData()
 	objLandInterface.Commands.DialogStart.texNum	= 0;
 	objLandInterface.Commands.DialogStart.event		= "BI_DialogStart";
 	objLandInterface.Commands.DialogStart.note		= LanguageConvertString(idLngFile, "land_DialogStart");
+	// Vex: Self Dialog Port -->
+	objLandInterface.Commands.TalkSelf.enable		= true;
+	objLandInterface.Commands.TalkSelf.picNum		= calcTextureIndex(4, 2);
+	objLandInterface.Commands.TalkSelf.selPicNum	= calcSelectedTextureIndex(4, 2);
+	objLandInterface.Commands.TalkSelf.texNum		= 0;
+	objLandInterface.Commands.TalkSelf.event		= "BI_TalkSelf";
+	objLandInterface.Commands.TalkSelf.note			= "Self Talk";
+	// <-- Vex: Self Dialog Port
 	objLandInterface.Commands.ItemsChange.enable	= true;
 	objLandInterface.Commands.ItemsChange.picNum	= calcTextureIndex(1, 2);
 	objLandInterface.Commands.ItemsChange.selPicNum	= calcSelectedTextureIndex(1, 2);
@@ -1081,6 +1128,11 @@ void BLI_SetPossibleCommands()
 
 	objLandInterface.Commands.FastReload.enable	= bTmpBool==true; // KK causes more problems than good && objLandInterface.Commands.DialogStart.enable==false;//MAXIMUS
 	bUseCommand = true;
+
+	// Vex: Self Dialog Port -->
+	objLandInterface.Commands.TalkSelf.enable = true;
+	bUseCommand = true;
+	// <-- Vex: Self Dialog Port
 
 	if(GetCharacterPerkUsing(mchref,"Rush"))
 	{

--- a/PROGRAM/DIALOGS/ENGLISH/MainHero_dialog.h
+++ b/PROGRAM/DIALOGS/ENGLISH/MainHero_dialog.h
@@ -1,0 +1,10 @@
+// Ported by Vex
+string DLG_TEXT[7] = {
+	"If you're seeing this, there's a bug in the code.",
+	"Exit",
+	"What to do ...",
+	"It would surely not hurt to rest a bit.",
+	"I changed my mind.",
+	"How many hours should I wait?",
+	"I suppose not, then."
+}

--- a/PROGRAM/DIALOGS/MainHero_dialog.c
+++ b/PROGRAM/DIALOGS/MainHero_dialog.c
@@ -1,0 +1,74 @@
+// Ported by Vex
+
+void ProcessDialogEvent()
+{
+	ref NPChar;
+	aref Link, NextDiag;
+
+	DeleteAttribute(&Dialog,"Links");
+
+	makeref(NPChar,CharacterRef);
+	makearef(Link, Dialog.Links);
+	makearef(NextDiag, NPChar.Dialog);
+
+    ref chr;
+    float  fTemp;
+    bool bOk;
+    
+	switch(Dialog.CurrentNode)
+	{
+        case "Exit":
+			NextDiag.CurrentNode = NextDiag.TempNode;
+			DialogExit_Self();
+		break;
+		
+		case "First time":
+	      	NextDiag.TempNode = "First time";
+
+	        Dialog.Text = "First time";
+			Link.l1 = "First time text (exit)";
+			Link.l1.go = "exit";
+		break;
+
+		case "TalkSelf_Main":
+	   		NextDiag.TempNode = "First time";
+			Dialog.Text = "What to do ...";
+
+			Link.l1 = "It would surely not hurt to rest a bit.";
+			Link.l1.go = "TalkSelf_Wait1";
+
+			Link.l10 = "I changed my mind.";
+			Link.l10.go = "exit";
+		break;
+
+		case "TalkSelf_Wait1":
+			Dialog.Text = "How many hours?";
+		
+			Link.l1.edit = "string";
+			Link.l1.go = "TalkSelf_Wait2";
+
+		break;
+		
+		case "TalkSelf_Wait2":
+			Dialog.Text = "Maybe not, then ..."; // If a valid integer is given, this won't have time to show up.
+
+			int iWaitHours = sti(Dialog.value);
+
+			if (iWaitHours > 0){
+				WaitDate("", 0, 0, 0, iWaitHours, 0);
+				LAi_Fade("", "");
+				RecalculateJumpTable();
+				Whr_UpdateWeather(false);
+				DialogExit_Self();
+			}
+			Link.l1 = "I changed my mind.";
+			Link.l1.go = "exit";
+		break;
+	}
+}
+
+void  DialogExit_Self()
+{
+    locCameraSleep(false);
+    DialogExit();
+}

--- a/PROGRAM/QUESTS/quests_common.c
+++ b/PROGRAM/QUESTS/quests_common.c
@@ -1040,6 +1040,12 @@ void CommonQuestComplete(string sQuestName)
 			Lai_SetPlayerType(pchar);
 			Pchar.dialog.filename = "blaze_dialog.c"; // PB: To ensure this is reset after using a custom file for self dialog
 		break;
+		
+		// Vex: Self Dialog Port -->
+		case "pchar_back_to_player":
+			Lai_SetPlayerType(pchar);
+		break;
+		// <-- Vex: Self Dialog Port
 
 		// Grey Roger: This is also taken from "standard"
 		// Needed for "Strange Things Going On", also for one of the Thiefbuster traps

--- a/RESOURCE/INI/TEXTS/ENGLISH/commands_name.txt
+++ b/RESOURCE/INI/TEXTS/ENGLISH/commands_name.txt
@@ -54,6 +54,7 @@ land_ItemsDead {Loot Corpse}
 land_FastReload {Fast Travel}
 land_ItemsUse {UseItem}
 land_DialogStart {Talk}
+land_TalkSelf {Talk to Self}
 land_ItemsChange {Exchange}
 land_TakeItem {Take Item}
 land_PlaceItem {Place Item}


### PR DESCRIPTION
The land interface now has a "Talk to Self" command. Selecting this allows the player to wait a given number of hours.

The icon for the command is currently the same as the one for "Talk". This is not elegant, but I'm not sure what art to use.

I'm open to suggestions.

# Images
## Talk to Self command
![CommandMenu](https://github.com/user-attachments/assets/864cd4ed-0642-4255-940d-d16b52d4ec01)
## Starting Dialogue
![dialog1](https://github.com/user-attachments/assets/e31a2945-9c18-4d98-9443-4b5536e485c8)
## Waiting Input
![dialog2](https://github.com/user-attachments/assets/0c8d4393-afe0-4188-ab8b-511fcdd82a4e)
## If Invalid Integer or 0 Is Input
![dialog3](https://github.com/user-attachments/assets/1261db1f-fb99-495c-81b6-f97e7540581c)

