### PR TITLE
Add dialog shortcut for cargo quests if you already have the needed goods

### DIFF
--- a/PROGRAM/DIALOGS/Blacksmith_fetch.c
+++ b/PROGRAM/DIALOGS/Blacksmith_fetch.c
@@ -30,6 +30,13 @@ void ProcessDialogEvent()
 			Link.l1.go = "agree fetch";
 			Link.l2 = DLG_TEXT[5];
 			Link.l2.go = "decline fetch";
+         // Peter Norton - PChar already has the cargo -->
+         if (GetCargoGoods(PChar, sti(NPChar.fetch_quest.good)) >= sti(NPChar.fetch_quest.amount))
+         {
+            Link.l3 = DLG_TEXT[17];
+            Link.l3.go = "fetch quest complete";
+         }
+         // <-- PN
 		break;
 		
 		case "fetch quest more runs":

--- a/PROGRAM/DIALOGS/ENGLISH/Blacksmith_fetch.h
+++ b/PROGRAM/DIALOGS/ENGLISH/Blacksmith_fetch.h
@@ -1,6 +1,6 @@
-string DLG_TEXT[19] = {
+string DLG_TEXT[18] = {
 "Folks say you got a big order. Need help?",
-"Indeed I am #ssir#. The store can't even keep up with my demand. Could you fetch me ",
+"Indeed I am #ssir#. The store can't even keep up with my demand. If you fetch me ",
 " I will pay you ",
 " gold coins. Please get it before ",
 "I'm your #sgender#. You will have those supplies in no time.",
@@ -15,5 +15,6 @@ string DLG_TEXT[19] = {
 "As promised, here is your pay. Thank you very much for getting these goods.",
 "I couldn't get your whole delivery in one go, so here is the first part.",
 "Ah, thank you very much. Please get the rest as soon as possible. I'm going to use these resources already, so if you don't deliver the rest I still have to cancel the order, but I can't return these resources either, just so you know.",
-"You know what, I will keep them with me then until I have everything",
+"You know what, I will keep them with me then until I have everything.",
+"Today is your lucky day, I have what you need in the hold of my ship.",
 };

--- a/PROGRAM/DIALOGS/ENGLISH/Gunsmith_fetch.h
+++ b/PROGRAM/DIALOGS/ENGLISH/Gunsmith_fetch.h
@@ -1,6 +1,6 @@
-string DLG_TEXT[19] = {
+string DLG_TEXT[18] = {
 "Folks say you got a big order. Need help?",
-"Indeed I am, #ssir#. The store can't even keep up with my demand. Could you fetch me ",
+"Indeed I am, #ssir#. The store can't even keep up with my demand. If you fetch me ",
 " I will pay you ",
 " gold coins. Please get it before ",
 "I'm your #sgender#. You will have those supplies in no time.",
@@ -16,4 +16,5 @@ string DLG_TEXT[19] = {
 "I couldn't get your whole delivery in one go, so here is the first part.",
 "Ah, thank you very much. Please get the rest as soon as possible. I'm going to use these resources already, so if you don't deliver the rest I still have to cancel the order, but I can't return these resources either, just so you know.",
 "You know what, I will keep them with me then until I have everything",
+"Today is your lucky day, I have what you need in the hold of my ship.",
 };

--- a/PROGRAM/DIALOGS/ENGLISH/apothecary_fetch.h
+++ b/PROGRAM/DIALOGS/ENGLISH/apothecary_fetch.h
@@ -1,6 +1,6 @@
-string DLG_TEXT[19] = {
+string DLG_TEXT[18] = {
 "Folks say you got a big order. Guess you need some supplies then?",
-"Aye, indeed I'm in need of some supplies. The store is all sold out. Could you fetch me ",
+"Aye, indeed I'm in need of some supplies. The store is all sold out. If you fetch me ",
 " I will pay you ",
 " gold coins. Please get it before ",
 "I'm your #sgender#. You will have those supplies in no time.",
@@ -15,5 +15,6 @@ string DLG_TEXT[19] = {
 "As promised, here is your pay. Thank you very much for getting these goods.",
 "I couldn't get your whole delivery in one go, so here is the first part.",
 "Ah thank you very much. Please get the rest as soon as possible. I'm going to use these resources already so if you dont deliver the rest I still have to cancel the order but I can't return these resources either, just so you know.",
-"You know what I will keep them with me then until I have everything",
+"You know what I will keep them with me then until I have everything.",
+"Today is your lucky day, I have what you need in the hold of my ship.",
 };

--- a/PROGRAM/DIALOGS/ENGLISH/shipyard.h
+++ b/PROGRAM/DIALOGS/ENGLISH/shipyard.h
@@ -1,6 +1,6 @@
-string DLG_TEXT[19] = {
+string DLG_TEXT[18] = {
 "Rumour has it that you need some help getting some resources, is that true?",
-"Aye, indeed I'm in need of some supplies. The storekeeper says he will not have any of these supplies any time soon. Could you fetch me ",
+"Aye, indeed I'm in need of some supplies. The storekeeper says he will not have any of these supplies any time soon. If you fetch me ",
 " I will pay you ",
 " gold coins. Please get it before ",
 "I'm your #sgender#. You will have those supplies in no time.",
@@ -15,5 +15,6 @@ string DLG_TEXT[19] = {
 "As promised, here is your pay. Thank you very much for getting these goods.",
 "I couldn't get your whole delivery in one go, so here is the first part.",
 "Ah, thank you very much. Please get the rest as soon as possible. I'm going to use these resources already, so if you don't deliver the rest I still have to cancel the order, but I can't return these resources either, just so you know.",
-"You know what, I will keep them with me then until I have everything",
+"You know what, I will keep them with me then until I have everything.",
+"Today is your lucky day, I have what you need in the hold of my ship.",
 };

--- a/PROGRAM/DIALOGS/ENGLISH/tailor.h
+++ b/PROGRAM/DIALOGS/ENGLISH/tailor.h
@@ -1,6 +1,6 @@
-string DLG_TEXT[19] = {
+string DLG_TEXT[18] = {
 "Folks say you got a big order. Guess you need some supplies then?",
-"Aye, indeed I'm in need of some supplies. The store is all sold out. Could you fetch me ",
+"Aye, indeed I'm in need of some supplies. The store is all sold out. If you fetch me ",
 " I will pay you ",
 " gold coins. Please get it before ",
 "I'm your #sgender#. You will have those supplies in no time.",
@@ -15,5 +15,6 @@ string DLG_TEXT[19] = {
 "As promised, here is your pay. Thank you very much for getting these goods.",
 "I couldn't get your whole delivery in one go, so here is the first part.",
 "Ah, thank you very much. Please get the rest as soon as possible. I'm going to use these resources already, so if you don't deliver the rest I still have to cancel the order, but I can't return these resources either, just so you know.",
-"You know what, I will keep them with me then until I have everything",
+"You know what, I will keep them with me then until I have everything.",
+"Today is your lucky day, I have what you need in the hold of my ship.",
 };

--- a/PROGRAM/DIALOGS/Gunsmith_fetch.c
+++ b/PROGRAM/DIALOGS/Gunsmith_fetch.c
@@ -29,6 +29,13 @@ void ProcessDialogEvent()
 			Link.l1.go = "agree fetch";
 			Link.l2 = DLG_TEXT[5];
 			Link.l2.go = "decline fetch";
+         // Peter Norton - PChar already has the cargo -->
+         if (GetCargoGoods(PChar, sti(NPChar.fetch_quest.good)) >= sti(NPChar.fetch_quest.amount))
+         {
+            Link.l3 = DLG_TEXT[17];
+            Link.l3.go = "fetch quest complete";
+         }
+         // <-- PN
 		break;
 		
 		case "fetch quest more runs":

--- a/PROGRAM/DIALOGS/shipyard.c
+++ b/PROGRAM/DIALOGS/shipyard.c
@@ -24,10 +24,17 @@ void ProcessDialogEvent()
 		case "fetch quest":
 			Preprocessor_Add("gender", GetMyAddressForm(NPChar, PChar, ADDR_GENDER, false, false)); // DeathDaisy
 			d.Text = DLG_TEXT[1] + NPChar.fetch_quest.amount + " " + XI_ConvertString(Goods[sti(NPChar.fetch_quest.good)].name) + DLG_TEXT[2] + NPChar.fetch_quest.money + DLG_TEXT[3]  + NPChar.fetch_quest.expire;
-			Link.l1 = DLG_TEXT[4];
-			Link.l1.go = "agree fetch";
-			Link.l2 = DLG_TEXT[5];
-			Link.l2.go = "decline fetch";
+               Link.l1 = DLG_TEXT[4];
+               Link.l1.go = "agree fetch";
+               Link.l2 = DLG_TEXT[5];
+               Link.l2.go = "decline fetch";
+               // Peter Norton - PChar already has the cargo -->
+               if (GetCargoGoods(PChar, sti(NPChar.fetch_quest.good)) >= sti(NPChar.fetch_quest.amount))
+               {
+                  Link.l3 = DLG_TEXT[17];
+                  Link.l3.go = "fetch quest complete";
+               }
+               // <-- PN
 		break;
 		
 		case "fetch quest more runs":

--- a/PROGRAM/DIALOGS/tailor.c
+++ b/PROGRAM/DIALOGS/tailor.c
@@ -28,6 +28,13 @@ void ProcessDialogEvent()
 			Link.l1.go = "agree fetch";
 			Link.l2 = DLG_TEXT[5];
 			Link.l2.go = "decline fetch";
+         // Peter Norton - PChar already has the cargo -->
+         if (GetCargoGoods(PChar, sti(NPChar.fetch_quest.good)) >= sti(NPChar.fetch_quest.amount))
+         {
+            Link.l3 = DLG_TEXT[17];
+            Link.l3.go = "fetch quest complete";
+         }
+         // <-- PN
 		break;
 		
 		case "fetch quest more runs":


### PR DESCRIPTION
I made an adjustment for my use in the .c files for the apothecary/blacksmith/gunsmith/tailor/shiyard cargo missions.
It adds a dialog for when the character already has the cargo necessary for the mission ("Today is your lucky day, I have what you need in the hold of my ship."), but I'm sharing the idea.

Credit to Peter Norton on the Discord