### PR TITLE
band-aid fix for self-talk issue (treasure hunt quests)

### DIFF
--- a/PROGRAM/DIALOGS/Enc_Walker.c
+++ b/PROGRAM/DIALOGS/Enc_Walker.c
@@ -1423,7 +1423,24 @@ void ProcessDialogEvent()
 		case "accept_secret":
 			Diag.CurrentNode = "get_out";
 			DialogExit();
+
+			PChar.settings.skipReloadShipsInLocation = true;
+
+			// TODO: Investigate and fix!
+			// VEX: If the ship reloads are not skipped,
+			//  a bug happens when GenerateTreasureQuest() runs.
+			//  The player's active action becomes talking to themself,
+			//  and can even 'trade' with themself.
+			//  (https://github.com/PiratesAhoy/new-horizons/issues/222)
+			//  I have tracked down the issue to the following call-stack:
+			//  GenerateTreasureQuest -> GenerateQuestShip -> GiveShip2Character -> LocLoadShips -> SendMessage(&locShips[n],"laa",MSG_SHIP_CREATE,&rCharacter,&rShip)
+			//  Somehow this engine-side call results in "procFindDialogChar()" getting "0" as the dlgChar, and
+			//  the ID 0 belongs to the player.
+
 			GenerateTreasureQuest();
+			
+			DeleteAttribute(PChar, "settings.skipReloadShipsInLocation");
+			
 			AddMoneyToCharacter(PChar, -sti(NPChar.sum));
 			PlayStereoSound("INTERFACE\took_item.flac");
 			DeleteAttribute(NPChar, "sum");

--- a/PROGRAM/NK.c
+++ b/PROGRAM/NK.c
@@ -293,7 +293,14 @@ void GiveShip2Character(ref char, string shiptype, string shipname, int cannon_t
 		SupplyShip(char); // Then add them again
 	}
 // KK -->
-	if (FindLoadedLocation() >= 0 && locNumShips > 0) {
+
+	ref PChar = GetMainCharacter();
+	bool bSkipShipReloads = CheckAttribute(PChar, "settings.skipReloadShipsInLocation") && PChar.settings.skipReloadShipsInLocation == true;
+
+	if (
+		!bSkipShipReloads &&
+		FindLoadedLocation() >= 0 && locNumShips > 0
+	) {
 		DeleteRiggingEnvironment();
 		LocLoadShips(&Locations[FindLoadedLocation()]);
 	}


### PR DESCRIPTION
fixes #222 

This is really just a band-aid fix. Why reloading the ships in the location causes the weird engine-side self-talk/self-exchange issue should be investigated.