### PR TITLE
fixed ship availability logic for Vanderdecken

### DIFF
--- a/PROGRAM/Ships/Ships.c
+++ b/PROGRAM/Ships/Ships.c
@@ -581,7 +581,7 @@ void FillShipsList(ref NPChar)
 		if (CheckAttribute(NPChar,"id") && NPChar.id == "Hendrick Vanderdecken") // PB: Enable the buying of unavailable quest ships
 		{
 			bool VanderdeckenShip = false;
-			if(sti(rShip.CanBuy) == false && sti(rShip.CanEncounter) == false)	VanderdeckenShip = true;
+			if(sti(rShip.CanBuy) == true && sti(rShip.CanEncounter) == false)	VanderdeckenShip = true;
 			if(HasSubStr(rShip.id, "Steam"))									VanderdeckenShip = true;
 			if(HasSubStr(rShip.id, "obj_"))										VanderdeckenShip = false;
 			if(!VanderdeckenShip) 												continue;


### PR DESCRIPTION
Corrected the condition for allowing the purchase of the Vanderdecken ship.

It was definitely a typo, right?