### PR TITLE
Fixed the Hoist the Colours conversation with Mings

### DIFF
--- a/PROGRAM/Storyline/JackSparrow/dialogs/ENGLISH/Sir Christopher Mings_dialog.h
+++ b/PROGRAM/Storyline/JackSparrow/dialogs/ENGLISH/Sir Christopher Mings_dialog.h
@@ -14,7 +14,7 @@ string DLG_TEXT[71] = {
 "Good lad, good lad. Give me a minute to leave here, then come to the room at the top of the stairs just opposite the shipyard. Better we're not seen leaving together.",
 "Very well, Sir Christopher. I will join you shortly.",
 "Ah! well, can't be helped I suppose. If you will excuse me. I feel the need for a doze.",
-"Oh! yes of course Sir Christopher. Good Day to you. [THINKS Or perhaps I should say good night!].",
+"Oh! yes of course Sir Christopher. Good Day to you. [THINKS: Or perhaps I should say good night!].",
 "Ah! Jack lad. You're here.",
 "CAPTAIN Jack if you don't mind Sir Christopher. [THINKS: And of course I'm here. You couldn't talk to me if I wasn't.]",
 "Whatever, Captain Jack, lad. Now down to business. You'll be wanting to talk payment of course.",

--- a/PROGRAM/Storyline/JackSparrow/dialogs/Sir Christopher Mings_dialog.c
+++ b/PROGRAM/Storyline/JackSparrow/dialogs/Sir Christopher Mings_dialog.c
@@ -310,7 +310,7 @@ void ProcessDialogEvent()
 			pchar.quest.Jacks_early_days = "first_meeting";
 			DialogExit();
 			NextDiag.CurrentNode = NextDiag.TempNode;
-//			AddDialogExitQuest("Start_Again_In_Tavern");	// GR: this doesn't seem to trigger
+			AddDialogExitQuest("Leave_Mings_At_Table");
 		break;
 
 		case "Exit_for_upstairs_meeting":

--- a/PROGRAM/Storyline/JackSparrow/dialogs/Sir Christopher Mings_dialog.c
+++ b/PROGRAM/Storyline/JackSparrow/dialogs/Sir Christopher Mings_dialog.c
@@ -107,7 +107,7 @@ void ProcessDialogEvent()
 		case "Introduction6":
 			dialog.text = DLG_TEXT[14];
 			link.l1 = DLG_TEXT[15];			
-			link.l1.go = "Exit_Introduction_and leave";
+			link.l1.go = "Exit_Introduction_and_leave";
 		break;
 		
 		case "Upstairs_meeting":
@@ -306,7 +306,7 @@ void ProcessDialogEvent()
 			AddDialogExitQuest("Sit_with_Sir_Christopher");
 		break;
 
-		case "Exit_Introduction_and leave":
+		case "Exit_Introduction_and_leave":
 			pchar.quest.Jacks_early_days = "first_meeting";
 			DialogExit();
 			NextDiag.CurrentNode = NextDiag.TempNode;

--- a/PROGRAM/Storyline/JackSparrow/quests/quests_reaction.c
+++ b/PROGRAM/Storyline/JackSparrow/quests/quests_reaction.c
@@ -496,13 +496,35 @@ void QuestComplete(string sQuestName)
 		break;
 
 		case "Start_Again_in_Tavern":
-			LAi_Fade("Start_Again_in_Tavern2", "");
+			//LAi_Fade("Start_Again_in_Tavern2", "");
+			LAi_QuestDelay("Start_Again_in_Tavern2", 0.1);
 		break;
 
 		case "Start_Again_in_Tavern2":
+			DeleteAttribute(&Locations[FindLocation("Oxbay_tavern")],"vcskip"); // PB
+		break;
+
+		case "Leave_Mings_At_Table":
+			DeleteAttribute(&Locations[FindLocation("Oxbay_tavern")],"vcskip"); // PB
+			LAi_QuestDelay("Mings_Refused_1", 0.1);
+		break;
+
+		case "Mings_Refused_1":
+			LAi_SetActorType(characterFromID("Sir Christopher Mings"));
+			LAi_ActorAnimation(characterFromID("Sir Christopher Mings"), "StandUp", "Mings_Refused_2", 1.0);
+		break;
+
+		case "Mings_Refused_2":
+			LAi_ActorGoToLocator(characterFromID("Sir Christopher Mings"), "goto", "goto4", "Mings_Refused_3", 5.0);
+		break;
+
+		case "Mings_Refused_3":
+			LAi_ActorGoToLocator(characterFromID("Sir Christopher Mings"), "reload", "reload1", "Mings_Refused_4", 10.0);
+		break;
+
+		case "Mings_Refused_4":
 			LAi_SetPlayerType(pchar);
 			DoQuestReloadToLocation("Oxbay_tavern", "goto", "goto2", "_");
-			DeleteAttribute(&Locations[FindLocation("Oxbay_tavern")],"vcskip"); // PB
 		break;
 
 		case "Mings_step_two":


### PR DESCRIPTION
- Small typo fix.
- Fixed a strange dialogue ID string.
- Fixed both paths (accepting and refusing) of the dialogue scene.

For the acceptance, it was the fader again, just like with #253. I think it has to do with the black fader interfering with the reload screen?

Refusing the offer just left the player sitting with the character until now. Apparently, Grey Rogers found this issue (based on the comment), but either no one fixed it, or the fix broke at one point. Hopefully he fixed it in his Gamma version lol.