### PR TITLE
engine.ini warning comments for interface size

### DIFF
--- a/engine.ini
+++ b/engine.ini
@@ -40,8 +40,8 @@ title = Beyond New Horizons
 target_version = latest
 
 [interface]
-screen_width = 640
-screen_height = 480
+screen_width = 640  ; DO NOT MODIFY! Use screen_x at the top instead!
+screen_height = 480 ; DO NOT MODIFY! Use screen_y at the top instead!
 
 [script]
 debuginfo = 1


### PR DESCRIPTION
I've been told by @Hammie that the `screen_width` and `screen_height` variables under `[interface]` should not be modified in `engine.ini`. However, nothing warns users about this at the moment. I thought it would be nice to add comments there.